### PR TITLE
Reject removal of caller from owners

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "repository": "https://github.com/research-ag/directory.git",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "setup": "dfx canister create --all && dfx build internet_identity && dfx generate && dfx deploy",

--- a/src/main.mo
+++ b/src/main.mo
@@ -61,6 +61,9 @@ actor class Directory(initialOwner : ?Principal) {
   };
 
   public shared ({ caller }) func removeOwner(principal : Principal) : async () {
+    if (Principal.equal(principal, caller)) {
+      throw Error.reject("Cannot remove yourself from owners");
+    };
     await* assertion.ownerAccess(caller);
     ownersMap.delete(principal);
   };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -109,6 +109,14 @@ describe("Directory", () => {
     expect(actor.addToken(ethCreatePayload)).rejects.toThrow();
   });
 
+  test("should not allow owners to remove themselves", async () => {
+    actor.setIdentity(userIdentity1);
+    await actor.addOwner(userIdentity1.getPrincipal());
+    expect(actor.removeOwner(userIdentity1.getPrincipal()))
+        .rejects
+        .toThrow("Cannot remove yourself from owners");
+  });
+
   test("should allow owners to add new token", async () => {
     actor.setIdentity(userIdentity1);
     await actor.addToken(btcCreatePayload);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -112,9 +112,9 @@ describe("Directory", () => {
   test("should not allow owners to remove themselves", async () => {
     actor.setIdentity(userIdentity1);
     await actor.addOwner(userIdentity1.getPrincipal());
-    expect(actor.removeOwner(userIdentity1.getPrincipal()))
-        .rejects
-        .toThrow("Cannot remove yourself from owners");
+    await expect(actor.removeOwner(userIdentity1.getPrincipal()))
+      .rejects
+      .toThrow("Cannot remove yourself from owners");
   });
 
   test("should allow owners to add new token", async () => {


### PR DESCRIPTION
This change will make sure directory can't be soft-locked by removing all usable owners from the list